### PR TITLE
Switch to Black for automated code formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
         run: brew install ledger
       - run: pip install -r requirements.txt -r requirements_dev.txt
       - run: python -m pytest
+      - run: black --check .
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         run: sudo apt install ledger
       - if: matrix.os == 'macos-latest'
         run: brew install ledger
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt -r requirements_dev.txt
       - run: python -m pytest
   docs:
     name: Documentation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
       - run: pip install -r requirements.txt -r requirements_dev.txt
       - run: python -m pytest
       - run: black --check .
+      - run: flake8 .
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/beancount2ledger/__init__.py
+++ b/beancount2ledger/__init__.py
@@ -35,8 +35,11 @@ def convert(entries, output_format="ledger", dcontext=None, config={}):
             for posting in entry.postings:
                 if posting.units is None:
                     continue
-                if (posting.meta and '__automatic__' in posting.meta
-                        and not '__residual__' in posting.meta):
+                if (
+                    posting.meta
+                    and "__automatic__" in posting.meta
+                    and not "__residual__" in posting.meta
+                ):
                     continue
                 dcontext.update(posting.units.number, posting.units.currency)
 
@@ -44,7 +47,7 @@ def convert(entries, output_format="ledger", dcontext=None, config={}):
         printer = HLedgerPrinter(dcontext=dcontext, config=config)
     else:
         printer = LedgerPrinter(dcontext=dcontext, config=config)
-    return '\n'.join(map_data(printer(entry), config) for entry in entries)
+    return "\n".join(map_data(printer(entry), config) for entry in entries)
 
 
 def convert_file(file, output_format="ledger", dcontext=None, config={}):

--- a/beancount2ledger/__init__.py
+++ b/beancount2ledger/__init__.py
@@ -38,7 +38,7 @@ def convert(entries, output_format="ledger", dcontext=None, config={}):
                 if (
                     posting.meta
                     and "__automatic__" in posting.meta
-                    and not "__residual__" in posting.meta
+                    and "__residual__" not in posting.meta
                 ):
                     continue
                 dcontext.update(posting.units.number, posting.units.currency)

--- a/beancount2ledger/cli.py
+++ b/beancount2ledger/cli.py
@@ -31,7 +31,7 @@ def get_config(user_config):
     all_config.append(xdg / "beancount2ledger" / "config.yaml")
     for config in all_config:
         if config.exists():
-            with open(config, 'r') as config_stream:
+            with open(config, "r") as config_stream:
                 return yaml.safe_load(config_stream)
     return {}
 
@@ -48,30 +48,28 @@ def cli():
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        '-f',
+        "-f",
         "--format",
         dest="format",
         action="store",
         choices=("ledger", "hledger"),
         default=default,
-        help=f"output format (default: {default})")
+        help=f"output format (default: {default})",
+    )
+    parser.add_argument("file", help="beancount file", type=argparse.FileType("r"))
     parser.add_argument(
-        'file', help='beancount file', type=argparse.FileType('r'))
+        "-c", "--config", help="config file", type=argparse.FileType("r")
+    )
     parser.add_argument(
-        '-c',
-        '--config',
-        help='config file',
-        type=argparse.FileType('r'))
-    parser.add_argument(
-        '-V',
+        "-V",
         "--version",
         action="version",
-        version=f"%(prog)s {beancount2ledger.__version__}")
+        version=f"%(prog)s {beancount2ledger.__version__}",
+    )
 
     args = parser.parse_args()
     config = get_config(args.config)
-    output = beancount2ledger.convert_file(
-        args.file.name, args.format, config=config)
+    output = beancount2ledger.convert_file(args.file.name, args.format, config=config)
     print(output)
 
 

--- a/beancount2ledger/common.py
+++ b/beancount2ledger/common.py
@@ -161,7 +161,7 @@ def set_default(config):
     Set some defaults for the config
     """
 
-    if not "indent" in config:
+    if "indent" not in config:
         config["indent"] = 2
     return config
 
@@ -197,7 +197,7 @@ def is_automatic_posting(posting):
 
     if not posting.meta:
         return False
-    if "__automatic__" in posting.meta and not "__residual__" in posting.meta:
+    if "__automatic__" in posting.meta and "__residual__" not in posting.meta:
         return True
     return False
 

--- a/beancount2ledger/common.py
+++ b/beancount2ledger/common.py
@@ -74,7 +74,8 @@ def postings_by_type(entry):
     Args:
       entry: An instance of Transaction.
     Returns:
-      A tuple of simple postings, postings with price conversions, postings held at cost.
+      A tuple of simple postings, postings with price conversions, postings held at
+      cost.
     """
     postings_at_cost = []
     postings_at_price = []

--- a/beancount2ledger/common.py
+++ b/beancount2ledger/common.py
@@ -15,7 +15,7 @@ from beancount.core import data
 from beancount.core import convert
 from beancount.core import amount
 
-ROUNDING_ACCOUNT = 'Equity:Rounding'
+ROUNDING_ACCOUNT = "Equity:Rounding"
 
 
 def ledger_flag(flag):
@@ -23,7 +23,7 @@ def ledger_flag(flag):
     Return the flag only if it's a valid flag in ledger
     """
 
-    if flag and flag in ('*', '!'):
+    if flag and flag in ("*", "!"):
         return flag
 
 
@@ -34,7 +34,7 @@ def ledger_str(text):
     Specifically, turn multi-line strings into a single line
     """
 
-    return text.replace('\n', '\\n')
+    return text.replace("\n", "\\n")
 
 
 def quote(currency):
@@ -42,7 +42,7 @@ def quote(currency):
     Add quotes around a currency string
     """
 
-    return f'"{currency}"' if re.search(r'[0-9\.-]', currency) else currency
+    return f'"{currency}"' if re.search(r"[0-9\.-]", currency) else currency
 
 
 def quote_match(match):
@@ -65,7 +65,7 @@ def quote_currency(string):
     Returns:
       A string of text, with the commodity expressions surrounded with quotes.
     """
-    return re.sub(r'\b({})\b'.format(amount.CURRENCY_RE), quote_match, string)
+    return re.sub(r"\b({})\b".format(amount.CURRENCY_RE), quote_match, string)
 
 
 def postings_by_type(entry):
@@ -123,8 +123,7 @@ def split_currency_conversions(entry):
     """
     assert isinstance(entry, data.Transaction)
 
-    (postings_simple, postings_at_price,
-     postings_at_cost) = postings_by_type(entry)
+    (postings_simple, postings_at_price, postings_at_cost) = postings_by_type(entry)
 
     converted = postings_at_cost and postings_at_price
     if converted:
@@ -133,20 +132,23 @@ def split_currency_conversions(entry):
         replacement_postings = []
         for posting_orig in postings_at_price:
             weight = convert.get_weight(posting_orig)
-            posting_pos = data.Posting(posting_orig.account, weight, None,
-                                       None, None, None)
-            posting_neg = data.Posting(posting_orig.account, -weight, None,
-                                       None, None, None)
+            posting_pos = data.Posting(
+                posting_orig.account, weight, None, None, None, None
+            )
+            posting_neg = data.Posting(
+                posting_orig.account, -weight, None, None, None, None
+            )
 
             currency_entry = entry._replace(
                 postings=[posting_orig, posting_neg],
-                narration=entry.narration + ' (Currency conversion)')
+                narration=entry.narration + " (Currency conversion)",
+            )
             new_entries.append(currency_entry)
             replacement_postings.append(posting_pos)
 
         converted_entry = entry._replace(
-            postings=(
-                postings_at_cost + postings_simple + replacement_postings))
+            postings=(postings_at_cost + postings_simple + replacement_postings)
+        )
         new_entries.append(converted_entry)
     else:
         new_entries = [entry]
@@ -170,11 +172,11 @@ def user_meta(meta):
     """
 
     ignore = [
-        '__tolerances__',
-        '__automatic__',
-        '__residual__',
-        'filename',
-        'lineno',
+        "__tolerances__",
+        "__automatic__",
+        "__residual__",
+        "filename",
+        "lineno",
     ]
     return {key: meta[key] for key in meta if key not in ignore}
 
@@ -195,7 +197,7 @@ def is_automatic_posting(posting):
 
     if not posting.meta:
         return False
-    if '__automatic__' in posting.meta and not '__residual__' in posting.meta:
+    if "__automatic__" in posting.meta and not "__residual__" in posting.meta:
         return True
     return False
 
@@ -231,7 +233,7 @@ def map_data(string, config):
         return string
 
     for account in account_map:
-         string = re.sub(rf'\b{account}(?=  |\t|$)', account_map[account], string)
+        string = re.sub(rf"\b{account}(?=  |\t|$)", account_map[account], string)
 
     def map_currency(match):
         currency = match.group(2)

--- a/beancount2ledger/hledger.py
+++ b/beancount2ledger/hledger.py
@@ -131,7 +131,10 @@ class HLedgerPrinter(LedgerPrinter):
             # flag_posting add config["indent"] for the indentation
             # of postings and add 2 to separate account from amount
             len_amount = max(0, 76 - (len(flag_posting) + 2 + 2))
-            posting_str = f"{flag_posting}  {quote_currency(pos_str):>{len_amount}} {quote_currency(price_str)}"
+            posting_str = (
+                f"{flag_posting}  {quote_currency(pos_str):>{len_amount}}"
+                f" {quote_currency(price_str)}"
+            )
         indent = " " * self.config["indent"]
         self.io.write(indent + posting_str.rstrip())
         self.io.write("\n")

--- a/beancount2ledger/hledger.py
+++ b/beancount2ledger/hledger.py
@@ -26,7 +26,7 @@ class HLedgerPrinter(LedgerPrinter):
     "Multi-method for printing directives in HLedger format."
 
     def format_meta(self, key, val):
-        """"
+        """ "
         Format metadata
         """
 
@@ -60,30 +60,28 @@ class HLedgerPrinter(LedgerPrinter):
             del meta[auxdate_key]
         flag = ledger_flag(entry.flag)
         if flag:
-            self.io.write(' ' + flag)
+            self.io.write(" " + flag)
         code_key = self.config.get("code")
         if code_key and not meta.get(code_key) is None:
             code = meta[code_key]
-            self.io.write(' (' + str(code) + ')')
+            self.io.write(" (" + str(code) + ")")
             del meta[code_key]
-        payee = ' '.join(strings)
+        payee = " ".join(strings)
         if payee:
-            self.io.write(' ' + payee)
-        self.io.write('\n')
+            self.io.write(" " + payee)
+        self.io.write("\n")
 
-        indent = ' ' * self.config["indent"]
+        indent = " " * self.config["indent"]
 
         if entry.tags:
-            self.io.write(indent +
-                          '; {}:\n'.format(':, '.join(sorted(entry.tags))))
+            self.io.write(indent + "; {}:\n".format(":, ".join(sorted(entry.tags))))
         if entry.links:
-            self.io.write(indent +
-                          '; Link: {}\n'.format(' '.join(sorted(entry.links))))
+            self.io.write(indent + "; Link: {}\n".format(" ".join(sorted(entry.links))))
 
         for key, val in meta.items():
             meta = self.format_meta(key, val)
             if meta:
-                self.io.write(indent + f'; {meta}\n')
+                self.io.write(indent + f"; {meta}\n")
 
         # If a posting without an amount is given and several amounts would
         # be added when balancing, beancount will create several postings.
@@ -102,11 +100,10 @@ class HLedgerPrinter(LedgerPrinter):
 
     def Posting(self, posting, entry):
         assert posting.account is not None
-        flag = f"{ledger_flag(posting.flag)} " if ledger_flag(
-            posting.flag) else ''
+        flag = f"{ledger_flag(posting.flag)} " if ledger_flag(posting.flag) else ""
         flag_posting = f"{flag}{posting.account}"
 
-        pos_str = ''
+        pos_str = ""
         # We don't use position.to_string() because that uses the same
         # dformat for amount and cost, but we want dformat from our
         # dcontext to format amounts to the right precision while
@@ -115,23 +112,30 @@ class HLedgerPrinter(LedgerPrinter):
             pos_str = posting.units.to_string(self.dformat)
         # Convert the cost as a price entry, that's what HLedger appears to want.
         if isinstance(posting.cost, position.Cost):
-            pos_str += ' @ ' + position.cost_to_str(
-                posting.cost, display_context.DEFAULT_FORMATTER, detail=False)
+            pos_str += " @ " + position.cost_to_str(
+                posting.cost, display_context.DEFAULT_FORMATTER, detail=False
+            )
 
-        price_str = ('@ {}'.format(posting.price.to_string())
-                     if posting.price is not None and posting.cost is None else
-                     '')
-        if posting.meta and '__automatic__' in posting.meta and not '__residual__' in posting.meta:
-            posting_str = f'{flag_posting}'
+        price_str = (
+            "@ {}".format(posting.price.to_string())
+            if posting.price is not None and posting.cost is None
+            else ""
+        )
+        if (
+            posting.meta
+            and "__automatic__" in posting.meta
+            and not "__residual__" in posting.meta
+        ):
+            posting_str = f"{flag_posting}"
         else:
             # Width we have available for the amount: take width of
             # flag_posting add config["indent"] for the indentation
             # of postings and add 2 to separate account from amount
             len_amount = max(0, 76 - (len(flag_posting) + 2 + 2))
-            posting_str = f'{flag_posting}  {quote_currency(pos_str):>{len_amount}} {quote_currency(price_str)}'
-        indent = ' ' * self.config["indent"]
+            posting_str = f"{flag_posting}  {quote_currency(pos_str):>{len_amount}} {quote_currency(price_str)}"
+        indent = " " * self.config["indent"]
         self.io.write(indent + posting_str.rstrip())
-        self.io.write('\n')
+        self.io.write("\n")
 
         meta = user_meta(posting.meta or {})
         postdate_key = self.config.get("postdate")
@@ -148,4 +152,4 @@ class HLedgerPrinter(LedgerPrinter):
         for key, val in meta.items():
             formatted_meta = self.format_meta(key, val)
             if meta:
-                self.io.write(2 * indent + f'; {formatted_meta}\n')
+                self.io.write(2 * indent + f"; {formatted_meta}\n")

--- a/beancount2ledger/hledger.py
+++ b/beancount2ledger/hledger.py
@@ -11,7 +11,6 @@ __license__ = "GPL-2.0-or-later"
 import datetime
 
 from beancount.core.amount import Amount
-from beancount.core import amount
 from beancount.core import position
 from beancount.core import interpolate
 from beancount.core import display_context
@@ -124,7 +123,7 @@ class HLedgerPrinter(LedgerPrinter):
         if (
             posting.meta
             and "__automatic__" in posting.meta
-            and not "__residual__" in posting.meta
+            and "__residual__" not in posting.meta
         ):
             posting_str = f"{flag_posting}"
         else:

--- a/beancount2ledger/ledger.py
+++ b/beancount2ledger/ledger.py
@@ -203,7 +203,10 @@ class LedgerPrinter:
             # flag_posting add config["indent"] for the indentation
             # of postings and add 2 to separate account from amount
             len_amount = max(0, 75 - (len(flag_posting) + self.config["indent"] + 2))
-            posting_str = f"{flag_posting}  {quote_currency(pos_str):>{len_amount}} {quote_currency(price_str)}"
+            posting_str = (
+                f"{flag_posting}  {quote_currency(pos_str):>{len_amount}}"
+                f" {quote_currency(price_str)}"
+            )
         indent = " " * self.config["indent"]
         self.io.write(indent + posting_str.rstrip())
         meta = user_meta(posting.meta or {})

--- a/beancount2ledger/ledger.py
+++ b/beancount2ledger/ledger.py
@@ -22,7 +22,12 @@ from beancount.core import display_context
 
 from .common import ROUNDING_ACCOUNT
 from .common import ledger_flag, ledger_str, quote_currency, postings_by_type, user_meta
-from .common import set_default, get_lineno, is_automatic_posting, filter_rounding_postings
+from .common import (
+    set_default,
+    get_lineno,
+    is_automatic_posting,
+    filter_rounding_postings,
+)
 
 
 class LedgerPrinter:
@@ -34,7 +39,8 @@ class LedgerPrinter:
         self.io = None
         self.dcontext = dcontext or display_context.DEFAULT_DISPLAY_CONTEXT
         self.dformat = self.dcontext.build(
-            precision=display_context.Precision.MOST_COMMON)
+            precision=display_context.Precision.MOST_COMMON
+        )
         self.config = set_default(config)
 
     def __call__(self, obj):
@@ -43,26 +49,25 @@ class LedgerPrinter:
         method(obj)
         return self.io.getvalue()
 
-
     def format_meta(self, key, val):
-        """"
+        """ "
         Format metadata
         """
 
         # See write_metadata() in beancount/parser/printer.py for allowed types
         if isinstance(val, str):
-            sep = ':'
+            sep = ":"
             val = ledger_str(val)
         elif isinstance(val, Decimal):
-            sep = '::'
+            sep = "::"
         elif isinstance(val, Amount):
-            sep = '::'
+            sep = "::"
         elif isinstance(val, datetime.date):
-            sep = '::'
+            sep = "::"
             val = f"[{val}]"
         elif isinstance(val, bool):
-            sep = '::'
-            val = 'true' if val else 'false'
+            sep = "::"
+            val = "true" if val else "false"
         elif isinstance(val, (dict, Inventory)):
             # Ignore dicts, don't print them out (according to printer.py)
             return
@@ -71,7 +76,6 @@ class LedgerPrinter:
         else:
             raise ValueError(f"Unexpected metadata type: {type(val)}")
         return f"{key}{sep} {val}"
-
 
     def Transaction(self, entry):
         """Transactions"""
@@ -101,30 +105,30 @@ class LedgerPrinter:
             del meta[auxdate_key]
         flag = ledger_flag(entry.flag)
         if flag:
-            self.io.write(' ' + flag)
+            self.io.write(" " + flag)
         code_key = self.config.get("code")
         if code_key and not meta.get(code_key) is None:
             code = meta[code_key]
-            self.io.write(' (' + str(code) + ')')
+            self.io.write(" (" + str(code) + ")")
             del meta[code_key]
-        payee = ' '.join(strings)
+        payee = " ".join(strings)
         if payee:
-            self.io.write(' ' + payee)
-        self.io.write('\n')
+            self.io.write(" " + payee)
+        self.io.write("\n")
 
-        indent = ' ' * self.config["indent"]
+        indent = " " * self.config["indent"]
 
         if entry.tags:
-            self.io.write(indent +
-                          '; :{}:\n'.format(':'.join(sorted(entry.tags))))
+            self.io.write(indent + "; :{}:\n".format(":".join(sorted(entry.tags))))
         if entry.links:
             self.io.write(
-                indent + '; Link: {}\n'.format(', '.join(sorted(entry.links))))
+                indent + "; Link: {}\n".format(", ".join(sorted(entry.links)))
+            )
 
         for key, val in meta.items():
             formatted_meta = self.format_meta(key, val)
             if meta:
-                self.io.write(indent + f'; {formatted_meta}\n')
+                self.io.write(indent + f"; {formatted_meta}\n")
 
         # If a posting without an amount is given and several amounts would
         # be added when balancing, beancount will create several postings.
@@ -145,11 +149,10 @@ class LedgerPrinter:
         """Postings"""
 
         assert posting.account is not None
-        flag = f"{ledger_flag(posting.flag)} " if ledger_flag(
-            posting.flag) else ''
+        flag = f"{ledger_flag(posting.flag)} " if ledger_flag(posting.flag) else ""
         flag_posting = f"{flag}{posting.account}"
 
-        pos_str = ''
+        pos_str = ""
         # We don't use position.to_string() because that uses the same
         # dformat for amount and cost, but we want dformat from our
         # dcontext to format amounts to the right precision while
@@ -160,9 +163,13 @@ class LedgerPrinter:
         # cost details, but we have to add them ourselves in the format
         # expected by ledger.
         if isinstance(posting.cost, position.Cost):
-            pos_str += ' {' + position.cost_to_str(
-                posting.cost, display_context.DEFAULT_FORMATTER,
-                detail=False) + '}'
+            pos_str += (
+                " {"
+                + position.cost_to_str(
+                    posting.cost, display_context.DEFAULT_FORMATTER, detail=False
+                )
+                + "}"
+            )
         if posting.cost:
             if posting.cost.date != entry.date:
                 pos_str += f" [{posting.cost.date}]"
@@ -170,33 +177,34 @@ class LedgerPrinter:
                 pos_str += f" ({posting.cost.label})"
 
         if posting.price is not None:
-            price_str = '@ {}'.format(posting.price.to_string())
+            price_str = "@ {}".format(posting.price.to_string())
         else:
             # Figure out if we need to insert a price on a posting held at cost.
             # See https://groups.google.com/d/msg/ledger-cli/35hA0Dvhom0/WX8gY_5kHy0J
             # and https://github.com/ledger/ledger/issues/630
             (postings_simple, _, __) = postings_by_type(entry)
             postings_no_amount = [
-                posting for posting in postings_simple
+                posting
+                for posting in postings_simple
                 if posting.units is None or is_automatic_posting(posting)
             ]
             cost = posting.cost
             if cost and not postings_no_amount and len(entry.postings) > 2:
-                price_str = '@ {}'.format(
-                    amount.Amount(cost.number, cost.currency).to_string())
+                price_str = "@ {}".format(
+                    amount.Amount(cost.number, cost.currency).to_string()
+                )
             else:
-                price_str = ''
+                price_str = ""
 
         if is_automatic_posting(posting):
-            posting_str = f'{flag_posting}'
+            posting_str = f"{flag_posting}"
         else:
             # Width we have available for the amount: take width of
             # flag_posting add config["indent"] for the indentation
             # of postings and add 2 to separate account from amount
-            len_amount = max(
-                0, 75 - (len(flag_posting) + self.config["indent"] + 2))
-            posting_str = f'{flag_posting}  {quote_currency(pos_str):>{len_amount}} {quote_currency(price_str)}'
-        indent = ' ' * self.config["indent"]
+            len_amount = max(0, 75 - (len(flag_posting) + self.config["indent"] + 2))
+            posting_str = f"{flag_posting}  {quote_currency(pos_str):>{len_amount}} {quote_currency(price_str)}"
+        indent = " " * self.config["indent"]
         self.io.write(indent + posting_str.rstrip())
         meta = user_meta(posting.meta or {})
         dates = []
@@ -206,16 +214,16 @@ class LedgerPrinter:
             del meta[postdate_key]
         auxdate_key = self.config.get("auxdate")
         if auxdate_key and isinstance(meta.get(auxdate_key), datetime.date):
-            dates.append('=' + str(meta[auxdate_key]))
+            dates.append("=" + str(meta[auxdate_key]))
             del meta[auxdate_key]
         if dates:
-            self.io.write('  ; [' + ''.join(dates) + ']')
-        self.io.write('\n')
+            self.io.write("  ; [" + "".join(dates) + "]")
+        self.io.write("\n")
 
         for key, val in meta.items():
             formatted_meta = self.format_meta(key, val)
             if meta:
-                self.io.write(2 * indent + f'; {formatted_meta}\n')
+                self.io.write(2 * indent + f"; {formatted_meta}\n")
 
     def Balance(self, entry):
         """Balance entries"""
@@ -229,15 +237,15 @@ class LedgerPrinter:
         """Note entries"""
 
         self.io.write(
-            ';; Note: {e.date:%Y-%m-%d} {e.account} {e.comment}\n'.format(
-                e=entry))
+            ";; Note: {e.date:%Y-%m-%d} {e.account} {e.comment}\n".format(e=entry)
+        )
 
     def Document(self, entry):
         """Document entries"""
 
         self.io.write(
-            ';; Document: {e.date:%Y-%m-%d} {e.account} {e.filename}\n'.format(
-                e=entry))
+            ";; Document: {e.date:%Y-%m-%d} {e.account} {e.filename}\n".format(e=entry)
+        )
 
     def Pad(self, entry):
         """Pad entries"""
@@ -247,49 +255,58 @@ class LedgerPrinter:
         # automatically, thus balancing the accounts. Ledger does not support
         # automatically padding, so we can just output this as a comment.
         self.io.write(
-            ';; Pad: {e.date:%Y-%m-%d} {e.account} {e.source_account}\n'.
-            format(e=entry))
+            ";; Pad: {e.date:%Y-%m-%d} {e.account} {e.source_account}\n".format(e=entry)
+        )
 
     def Commodity(self, entry):
         "Commodity declarations" ""
 
         # No need for declaration.
-        self.io.write('commodity {e.currency}\n'.format(e=entry))
+        self.io.write("commodity {e.currency}\n".format(e=entry))
 
     def Open(self, entry):
         """Account open statements"""
 
-        self.io.write('account {e.account}\n'.format(e=entry))
+        self.io.write("account {e.account}\n".format(e=entry))
         if entry.currencies:
-            self.io.write('  assert {}\n'.format(' | '.join(
-                'commodity == "{}"'.format(currency)
-                for currency in entry.currencies)))
+            self.io.write(
+                "  assert {}\n".format(
+                    " | ".join(
+                        'commodity == "{}"'.format(currency)
+                        for currency in entry.currencies
+                    )
+                )
+            )
 
     def Close(self, entry):
         """Account close statements"""
 
-        self.io.write(
-            ';; Close: {e.date:%Y-%m-%d} close {e.account}\n'.format(e=entry))
+        self.io.write(";; Close: {e.date:%Y-%m-%d} close {e.account}\n".format(e=entry))
 
     def Price(self, entry):
         """Price entries"""
 
-        self.io.write('P {:%Y-%m-%d} {:<26} {:>35}\n'.format(
-            entry.date, quote_currency(entry.currency), str(entry.amount)))
+        self.io.write(
+            "P {:%Y-%m-%d} {:<26} {:>35}\n".format(
+                entry.date, quote_currency(entry.currency), str(entry.amount)
+            )
+        )
 
     def Event(self, entry):
         """ Event entries"""
 
         self.io.write(
-            ';; Event: {e.date:%Y-%m-%d} "{e.type}" "{e.description}"\n'.
-            format(e=entry))
+            ';; Event: {e.date:%Y-%m-%d} "{e.type}" "{e.description}"\n'.format(e=entry)
+        )
 
     def Query(self, entry):
         """Query entries"""
 
         self.io.write(
-            ';; Query: {e.date:%Y-%m-%d} "{e.name}" "{e.query_string}"\n'.
-            format(e=entry))
+            ';; Query: {e.date:%Y-%m-%d} "{e.name}" "{e.query_string}"\n'.format(
+                e=entry
+            )
+        )
 
     def Custom(self, entry):
         """Custom entries"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,8 @@ requires = [
   "setuptools_scm",
 ]
 build-backend = "setuptools.build_meta"
+
+
+[tool.black]
+line-length = 88
+target-version = ['py37']

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 black==20.8b1
+flake8
 mkdocs>=1.1
 mkdocs-exclude>=1.0.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,3 @@
+black==20.8b1
 mkdocs>=1.1
 mkdocs-exclude>=1.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,10 @@ exclude = tests
 [options.data_files]
 share/man/man1 =
     docs/beancount2ledger.1
+
+[flake8]
+# E203: whitespaces before ':' <https://github.com/psf/black/issues/315>
+# E231: missing whitespace after ','
+# W503: line break before binary operator <https://github.com/psf/black/issues/52>
+ignore = E203,E231,W503
+max-line-length = 88

--- a/tests/hledger_test.py
+++ b/tests/hledger_test.py
@@ -28,15 +28,16 @@ class TestHLedgerConversion(test_utils.TestCase):
     @loader.load_doc()
     def test_tags_links(self, entries, _, __):
         """
-          2019-01-25 open Assets:A
-          2019-01-25 open Assets:B
+        2019-01-25 open Assets:A
+        2019-01-25 open Assets:B
 
-          2019-01-25 * "Test tags" #foo ^link2 #bar #baz ^link1
-            Assets:A                       10.00 EUR
-            Assets:B                      -10.00 EUR
+        2019-01-25 * "Test tags" #foo ^link2 #bar #baz ^link1
+          Assets:A                       10.00 EUR
+          Assets:B                      -10.00 EUR
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines("""
+        self.assertLines(
+            """
           account Assets:A
 
           account Assets:B
@@ -46,32 +47,35 @@ class TestHLedgerConversion(test_utils.TestCase):
             ; Link: link1 link2
             Assets:A                       10.00 EUR
             Assets:B                      -10.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_cost(self, entries, _, __):
         """
-          2020-01-01 open Assets:Bank
-          2020-01-01 open Expenses:Grocery
+        2020-01-01 open Assets:Bank
+        2020-01-01 open Expenses:Grocery
 
-          2020-01-01 * "Grocery"  "Salad"
-              Expenses:Grocery                5 SALAD  {1.00 USD} @   1.00 USD
-              Assets:Bank
+        2020-01-01 * "Grocery"  "Salad"
+            Expenses:Grocery                5 SALAD  {1.00 USD} @   1.00 USD
+            Assets:Bank
 
-          2020-01-01 * "Grocery"  "Salad"
-              Expenses:Grocery                5 SALAD  {1.00 USD} @@  5.00 USD
-              Assets:Bank
+        2020-01-01 * "Grocery"  "Salad"
+            Expenses:Grocery                5 SALAD  {1.00 USD} @@  5.00 USD
+            Assets:Bank
 
-          2020-01-01 * "Grocery"  "Salad"
-              Expenses:Grocery                5 SALAD {{5.00 USD}} @  1.00 USD
-              Assets:Bank
+        2020-01-01 * "Grocery"  "Salad"
+            Expenses:Grocery                5 SALAD {{5.00 USD}} @  1.00 USD
+            Assets:Bank
 
-          2020-01-01 * "Grocery"  "Salad"
-              Expenses:Grocery                5 SALAD {{5.00 USD}} @@ 5.00 USD
-              Assets:Bank
+        2020-01-01 * "Grocery"  "Salad"
+            Expenses:Grocery                5 SALAD {{5.00 USD}} @@ 5.00 USD
+            Assets:Bank
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines("""
+        self.assertLines(
+            """
           account Assets:Bank
 
           account Expenses:Grocery
@@ -91,25 +95,28 @@ class TestHLedgerConversion(test_utils.TestCase):
           2020-01-01 * Grocery | Salad
             Expenses:Grocery                                                 5 SALAD @ 1.00 USD
             Assets:Bank
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_metadata_entry(self, entries, _, ___):
         """
-          2020-01-01 open Assets:Test
+        2020-01-01 open Assets:Test
 
-          2020-07-23 * "Test metadata"
-            string: "foo"
-            year: 2020
-            amount: 10.00 EUR
-            date: 2020-07-19
-            none:
-            bool: TRUE
-            Assets:Test     10.00 EUR
-            Assets:Test    -10.00 EUR
+        2020-07-23 * "Test metadata"
+          string: "foo"
+          year: 2020
+          amount: 10.00 EUR
+          date: 2020-07-19
+          none:
+          bool: TRUE
+          Assets:Test     10.00 EUR
+          Assets:Test    -10.00 EUR
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines("""
+        self.assertLines(
+            """
           account Assets:Test
 
           2020-07-23 * Test metadata
@@ -121,25 +128,28 @@ class TestHLedgerConversion(test_utils.TestCase):
             ; bool: True
             Assets:Test                                                      10.00 EUR
             Assets:Test                                                     -10.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_metadata_posting(self, entries, _, ___):
         """
-          2020-01-01 open Assets:Test
+        2020-01-01 open Assets:Test
 
-          2020-07-23 * "Test metadata"
-            Assets:Test     10.00 EUR
-            Assets:Test    -10.00 EUR
-            string: "foo"
-            year: 2020
-            amount: 10.00 EUR
-            date: 2020-07-19
-            none:
-            bool: FALSE
+        2020-07-23 * "Test metadata"
+          Assets:Test     10.00 EUR
+          Assets:Test    -10.00 EUR
+          string: "foo"
+          year: 2020
+          amount: 10.00 EUR
+          date: 2020-07-19
+          none:
+          bool: FALSE
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines("""
+        self.assertLines(
+            """
           account Assets:Test
 
           2020-07-23 * Test metadata
@@ -151,43 +161,46 @@ class TestHLedgerConversion(test_utils.TestCase):
               ; date: 2020-07-19
               ; none:
               ; bool: False
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_auxdate(self, entries, _, ___):
         """
-            2020-01-01 open Assets:Test
-            2020-01-01 open Equity:Opening-Balance
+        2020-01-01 open Assets:Test
+        2020-01-01 open Equity:Opening-Balance
 
-            2020-11-12 * "Test with aux date"
-              aux-date: 2020-11-03
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Test with aux date"
+          aux-date: 2020-11-03
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Test with transaction and posting aux date"
-              aux-date: 2020-11-03
-              Assets:Test                        10.00 EUR
-                aux-date: 2020-11-04
-              Equity:Opening-Balance
+        2020-11-12 * "Test with transaction and posting aux date"
+          aux-date: 2020-11-03
+          Assets:Test                        10.00 EUR
+            aux-date: 2020-11-04
+          Equity:Opening-Balance
 
-            2020-11-12 * "Test with posting date"
-              Assets:Test                        10.00 EUR
-                postdate: 2020-11-03
-              Equity:Opening-Balance            -10.00 EUR
-                postdate: 2020-11-04
-                test: "foo"
+        2020-11-12 * "Test with posting date"
+          Assets:Test                        10.00 EUR
+            postdate: 2020-11-03
+          Equity:Opening-Balance            -10.00 EUR
+            postdate: 2020-11-04
+            test: "foo"
 
-            2020-11-12 * "Testing with posting date and posting aux date"
-              Assets:Test                        10.00 EUR
-                aux-date: 2020-11-04
-                postdate: 2020-11-03
-              Equity:Opening-Balance            -10.00 EUR
-                postdate: 2020-11-03
-                aux-date: 2020-11-04
-                test: "foo"
+        2020-11-12 * "Testing with posting date and posting aux date"
+          Assets:Test                        10.00 EUR
+            aux-date: 2020-11-04
+            postdate: 2020-11-03
+          Equity:Opening-Balance            -10.00 EUR
+            postdate: 2020-11-03
+            aux-date: 2020-11-04
+            test: "foo"
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             account Equity:Opening-Balance
@@ -219,11 +232,14 @@ class TestHLedgerConversion(test_utils.TestCase):
                 ; aux-date: 2020-11-04
                 ; test: foo
 
-        """, result)
+        """,
+            result,
+        )
 
         config = {"auxdate": "aux-date", "postdate": "postdate"}
         result = beancount2ledger.convert(entries, "hledger", config=config)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             account Equity:Opening-Balance
@@ -252,11 +268,14 @@ class TestHLedgerConversion(test_utils.TestCase):
                 ; test: foo
                 ; date: 2020-11-03
                 ; date2: 2020-11-04
-        """, result)
+        """,
+            result,
+        )
 
         config = {"auxdate": "aux-date"}
         result = beancount2ledger.convert(entries, "hledger", config=config)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             account Equity:Opening-Balance
@@ -285,48 +304,51 @@ class TestHLedgerConversion(test_utils.TestCase):
                 ; postdate: 2020-11-03
                 ; test: foo
                 ; date2: 2020-11-04
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_code(self, entries, _, ___):
         """
-            2020-01-01 open Assets:Test
+        2020-01-01 open Assets:Test
 
-            2020-01-01 open Equity:Opening-Balance
+        2020-01-01 open Equity:Opening-Balance
 
-            2020-11-12 * "No code"
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "No code"
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Code is integer"
-              code: 1234
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Code is integer"
+          code: 1234
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Code is string"
-              code: "string"
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Code is string"
+          code: "string"
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Code is date"
-              code: 2020-11-12
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Code is date"
+          code: 2020-11-12
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Code is empty"
-              code:
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Code is empty"
+          code:
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Code and aux-date"
-              aux-date: 2020-11-03
-              code: 1234
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Code and aux-date"
+          aux-date: 2020-11-03
+          code: 1234
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
         """
 
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             account Equity:Opening-Balance
@@ -360,11 +382,14 @@ class TestHLedgerConversion(test_utils.TestCase):
               ; code: 1234
               Assets:Test                                                     10.00 EUR
               Equity:Opening-Balance
-        """, result)
+        """,
+            result,
+        )
 
         config = {"code": "code", "auxdate": "aux-date"}
         result = beancount2ledger.convert(entries, "hledger", config=config)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             account Equity:Opening-Balance
@@ -393,29 +418,32 @@ class TestHLedgerConversion(test_utils.TestCase):
             2020-11-12=2020-11-03 * (1234) Code and aux-date
                 Assets:Test                                                   10.00 EUR
                 Equity:Opening-Balance
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_retain_precision(self, entries, _, ___):
         """
-            2010-01-01 open Expenses:Nutrition:Food
-            2010-01-01 open Assets:Bank
-            2010-01-01 open Assets:Investments
+        2010-01-01 open Expenses:Nutrition:Food
+        2010-01-01 open Assets:Bank
+        2010-01-01 open Assets:Investments
 
-            2020-01-10 * "Supermarket"
-              Expenses:Nutrition:Food  150.75 THB @ 0.03310116086236 USD
-              Assets:Bank                                      -4.99 USD
+        2020-01-10 * "Supermarket"
+          Expenses:Nutrition:Food  150.75 THB @ 0.03310116086236 USD
+          Assets:Bank                                      -4.99 USD
 
-            2020-01-10 * "Supermarket"
-              Expenses:Nutrition:Food  150.75 THB @ 0.025207296849 GBP
-              Assets:Bank                                    -3.80 GBP
+        2020-01-10 * "Supermarket"
+          Expenses:Nutrition:Food  150.75 THB @ 0.025207296849 GBP
+          Assets:Bank                                    -3.80 GBP
 
-            2020-02-28 * "Bought GB00BPN5P782"
-              Assets:Investments           1 GB00BPN5P782 {101.689996215 GBP}
-              Assets:Investments                                 -101.69 GBP
+        2020-02-28 * "Bought GB00BPN5P782"
+          Assets:Investments           1 GB00BPN5P782 {101.689996215 GBP}
+          Assets:Investments                                 -101.69 GBP
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Expenses:Nutrition:Food
 
             account Assets:Bank
@@ -433,28 +461,31 @@ class TestHLedgerConversion(test_utils.TestCase):
             2020-02-28 * Bought GB00BPN5P782
               Assets:Investments                    1 "GB00BPN5P782" @ 101.689996215 GBP
               Assets:Investments                                             -101.69 GBP
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_rounding(self, entries, _, ___):
         """
-            2010-01-01 open Expenses:Test
-            2010-01-01 open Assets:Bank
+        2010-01-01 open Expenses:Test
+        2010-01-01 open Assets:Bank
 
-            2020-01-10 * "Test"
-              Expenses:Test                           4.990 USD
-              Assets:Bank                            -4.990 USD
+        2020-01-10 * "Test"
+          Expenses:Test                           4.990 USD
+          Assets:Bank                            -4.990 USD
 
-            2020-01-10 * "Test: will fail in ledger due to precision of USD"
-              Expenses:Test            150.75 THB @ 0.03344 USD
-              Assets:Bank                             -5.04 USD
+        2020-01-10 * "Test: will fail in ledger due to precision of USD"
+          Expenses:Test            150.75 THB @ 0.03344 USD
+          Assets:Bank                             -5.04 USD
 
-            2020-01-10 * "Test: will fail in ledger due to precision of USD"
-              Expenses:Test               140.1 THB @ 0.021 USD
-              Assets:Bank                             -2.94 USD
+        2020-01-10 * "Test: will fail in ledger due to precision of USD"
+          Expenses:Test               140.1 THB @ 0.021 USD
+          Assets:Bank                             -2.94 USD
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Expenses:Test
 
             account Assets:Bank
@@ -472,28 +503,31 @@ class TestHLedgerConversion(test_utils.TestCase):
               Expenses:Test                                                   140.10 THB @ 0.021 USD
               Assets:Bank                                                     -2.940 USD
               Equity:Rounding                                                 -0.002 USD
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_avoid_too_much_precision(self, entries, _, ___):
         """
-            2020-01-01 open Assets:Property
-            2020-01-01 open Equity:Opening-Balance
+        2020-01-01 open Assets:Property
+        2020-01-01 open Equity:Opening-Balance
 
-            2020-10-23 * "Test of precision for EUR"
-                Assets:Property               0.11110000 FOO {300.00 EUR}
-                Equity:Opening-Balance                        -33.33 EUR
+        2020-10-23 * "Test of precision for EUR"
+            Assets:Property               0.11110000 FOO {300.00 EUR}
+            Equity:Opening-Balance                        -33.33 EUR
 
-            2020-10-23 * "Test of precision for EUR"
-                Assets:Property               0.11110000 FOO {300.00 EUR}
-                Equity:Opening-Balance
+        2020-10-23 * "Test of precision for EUR"
+            Assets:Property               0.11110000 FOO {300.00 EUR}
+            Equity:Opening-Balance
 
-            2020-10-23 * "Test of precision for EUR"
-                Assets:Property                   0.1111 FOO {300.00 EUR}
-                Equity:Opening-Balance
+        2020-10-23 * "Test of precision for EUR"
+            Assets:Property                   0.1111 FOO {300.00 EUR}
+            Equity:Opening-Balance
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Property
 
             account Equity:Opening-Balance
@@ -509,21 +543,24 @@ class TestHLedgerConversion(test_utils.TestCase):
             2020-10-23 * Test of precision for EUR
               Assets:Property                                0.11110000 FOO @ 300.00 EUR
               Equity:Opening-Balance
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_avoid_multiple_null_postings(self, entries, _, ___):
         """
-            2010-01-01 open Assets:Cash
-            2010-01-01 open Equity:Opening-balance
+        2010-01-01 open Assets:Cash
+        2010-01-01 open Equity:Opening-balance
 
-            2020-01-01 * "Opening balance: cash"
-              Assets:Cash                                               0.10 EUR
-              Assets:Cash                                               1.00 GBP
-              Equity:Opening-balance
+        2020-01-01 * "Opening balance: cash"
+          Assets:Cash                                               0.10 EUR
+          Assets:Cash                                               1.00 GBP
+          Equity:Opening-balance
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Cash
 
             account Equity:Opening-balance
@@ -532,21 +569,24 @@ class TestHLedgerConversion(test_utils.TestCase):
               Assets:Cash                                                       0.10 EUR
               Assets:Cash                                                       1.00 GBP
               Equity:Opening-balance
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_add_price_when_needed(self, entries, _, ___):
         """
-            2020-01-01 open Assets:Property
-            2020-01-01 open Equity:Opening-Balance
+        2020-01-01 open Assets:Property
+        2020-01-01 open Equity:Opening-Balance
 
-            2020-11-13 * "Cost without price"
-                Assets:Property                   0.1 FOO {300.00 EUR}
-                Assets:Property                   0.2 BAR {200.00 EUR}
-                Equity:Opening-Balance         -70.00 EUR
+        2020-11-13 * "Cost without price"
+            Assets:Property                   0.1 FOO {300.00 EUR}
+            Assets:Property                   0.2 BAR {200.00 EUR}
+            Equity:Opening-Balance         -70.00 EUR
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Property
 
             account Equity:Opening-Balance
@@ -555,21 +595,24 @@ class TestHLedgerConversion(test_utils.TestCase):
               Assets:Property                                      0.1 FOO @ 300.00 EUR
               Assets:Property                                      0.2 BAR @ 200.00 EUR
               Equity:Opening-Balance                                         -70.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_keep_zero_amounts(self, entries, _, ___):
         """
-            2010-01-01 open Assets:Investments
-            2010-01-01 open Expenses:Fees:Investments
+        2010-01-01 open Assets:Investments
+        2010-01-01 open Expenses:Fees:Investments
 
-            2020-05-24 * "Bought ETH"
-              Assets:Investments                     0.00000221 ETH {190.60 EUR}
-              Expenses:Fees:Investments                                 0.00 EUR
-              Assets:Investments                                       -0.00 EUR
+        2020-05-24 * "Bought ETH"
+          Assets:Investments                     0.00000221 ETH {190.60 EUR}
+          Expenses:Fees:Investments                                 0.00 EUR
+          Assets:Investments                                       -0.00 EUR
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Investments
 
             account Expenses:Fees:Investments
@@ -578,23 +621,26 @@ class TestHLedgerConversion(test_utils.TestCase):
               Assets:Investments                            0.00000221 ETH @ 190.60 EUR
               Expenses:Fees:Investments                                        0.00 EUR
               Assets:Investments                                               0.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_preserve_posting_order(self, entries, _, ___):
         """
-            2010-01-01 open Assets:Test
+        2010-01-01 open Assets:Test
 
-            2020-07-24 * "Posting order"
-              Assets:Test        1000.00 EUR
-              Assets:Test       -1000.00 EUR
-              Assets:Test        1000.00 EUREUREUREUREUR
-              Assets:Test       -1000.00 EUREUREUREUREUR
-              Assets:Test        1000.00 EUR
-              Assets:Test       -1000.00 EUR
+        2020-07-24 * "Posting order"
+          Assets:Test        1000.00 EUR
+          Assets:Test       -1000.00 EUR
+          Assets:Test        1000.00 EUREUREUREUREUR
+          Assets:Test       -1000.00 EUREUREUREUREUR
+          Assets:Test        1000.00 EUR
+          Assets:Test       -1000.00 EUR
         """
         result = beancount2ledger.convert(entries, "hledger")
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             2020-07-24 * Posting order
@@ -604,32 +650,36 @@ class TestHLedgerConversion(test_utils.TestCase):
               Assets:Test                                       -1000.00 EUREUREUREUREUR
               Assets:Test                                                    1000.00 EUR
               Assets:Test                                                   -1000.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     def test_example(self):
         """
         Test converted example with hledger
         """
-        with tempfile.NamedTemporaryFile('w',
-                                         suffix='.beancount',
-                                         encoding='utf-8') as beanfile:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".beancount", encoding="utf-8"
+        ) as beanfile:
             # Generate an example Beancount file.
-            example.write_example_file(datetime.date(1980, 1, 1),
-                                       datetime.date(2010, 1, 1),
-                                       datetime.date(2014, 1, 1),
-                                       reformat=True,
-                                       file=beanfile)
+            example.write_example_file(
+                datetime.date(1980, 1, 1),
+                datetime.date(2010, 1, 1),
+                datetime.date(2014, 1, 1),
+                reformat=True,
+                file=beanfile,
+            )
             beanfile.flush()
 
             # Convert the file to HLedger format.
             #
             # Note: don't bother parsing for now, just a smoke test to make sure
             # we don't fail on run.
-            with tempfile.NamedTemporaryFile('w', suffix='.hledger') as lgrfile:
+            with tempfile.NamedTemporaryFile("w", suffix=".hledger") as lgrfile:
                 result = beancount2ledger.convert_file(beanfile.name, "hledger")
                 lgrfile.write(result)
                 lgrfile.flush()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/hledger_test.py
+++ b/tests/hledger_test.py
@@ -95,7 +95,7 @@ class TestHLedgerConversion(test_utils.TestCase):
           2020-01-01 * Grocery | Salad
             Expenses:Grocery                                                 5 SALAD @ 1.00 USD
             Assets:Bank
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 
@@ -461,7 +461,7 @@ class TestHLedgerConversion(test_utils.TestCase):
             2020-02-28 * Bought GB00BPN5P782
               Assets:Investments                    1 "GB00BPN5P782" @ 101.689996215 GBP
               Assets:Investments                                             -101.69 GBP
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 
@@ -503,7 +503,7 @@ class TestHLedgerConversion(test_utils.TestCase):
               Expenses:Test                                                   140.10 THB @ 0.021 USD
               Assets:Bank                                                     -2.940 USD
               Equity:Rounding                                                 -0.002 USD
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 

--- a/tests/ledger_test.py
+++ b/tests/ledger_test.py
@@ -117,7 +117,7 @@ class TestLedgerUtilityFunctionsOnPostings(cmptest.TestCase):
             Expenses:Commissions                 9.95 USD
             Assets:CA:Investment:Cash       -2,609.946534 USD
 
-        """,
+        """,  # NoQA: E501 line too long
             new_entries,
         )
 
@@ -199,7 +199,7 @@ class TestLedgerConversion(test_utils.TestCase):
             Expenses:Restaurant                                                     50.02 USD
             Assets:Cash
 
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 
@@ -370,7 +370,7 @@ class TestLedgerConversion(test_utils.TestCase):
         2020-02-03 * "Super Shop"  "New computer"
           Expenses:Computers       1 COMPUTER {900.00 USD, 2019-12-25} @ 1100.00 USD
           Assets:Bank
-        """
+        """  # NoQA: E501 line too long
         result = beancount2ledger.convert(entries)
         self.assertLines(
             """
@@ -389,7 +389,7 @@ class TestLedgerConversion(test_utils.TestCase):
           2020-02-03 * Super Shop | New computer
             Expenses:Computers                      1 COMPUTER {900.00 USD} [2019-12-25] @ 1100.00 USD
             Assets:Bank
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 
@@ -411,7 +411,7 @@ class TestLedgerConversion(test_utils.TestCase):
           Assets:Test                                                                         -1000.00 EUR
           * Assets:Test     100000.00 EUREUREUREUREUR
           Assets:Test      -100000.00 EUREUREUREUREUR
-        """
+        """  # NoQA: E501 line too long
         result = beancount2ledger.convert(entries)
         len_postings = [len(line) for line in result.rstrip().split("\n")]
         self.assertEqual(len_postings[-10:-1:2], [75, 75, 80, 98, 75])
@@ -603,7 +603,7 @@ class TestLedgerConversion(test_utils.TestCase):
               Equity:Opening-Balance                                         -10.00 EUR  ; [2020-11-03=2020-11-04]
                 ; test: foo
 
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 
@@ -636,7 +636,7 @@ class TestLedgerConversion(test_utils.TestCase):
               Equity:Opening-Balance                                         -10.00 EUR  ; [=2020-11-04]
                 ; date:: [2020-11-03]
                 ; test: foo
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 
@@ -792,7 +792,7 @@ class TestLedgerConversion(test_utils.TestCase):
             2020-02-28 * Bought GB00BPN5P782
               Assets:Investments                   1 "GB00BPN5P782" {101.689996215 GBP}
               Assets:Investments                                            -101.69 GBP
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 
@@ -834,7 +834,7 @@ class TestLedgerConversion(test_utils.TestCase):
               Expenses:Test                                                   140.10 THB @ 0.021 USD
               Assets:Bank                                                     -2.940 USD
               Equity:Rounding                                                 -0.002 USD
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 
@@ -926,7 +926,7 @@ class TestLedgerConversion(test_utils.TestCase):
               Assets:Property                                      0.1 FOO {300.00 EUR} @ 300.00 EUR
               Assets:Property                                      0.2 BAR {200.00 EUR} @ 200.00 EUR
               Equity:Opening-Balance                                         -70.00 EUR
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 
@@ -952,7 +952,7 @@ class TestLedgerConversion(test_utils.TestCase):
               Assets:Investments                            0.00000221 ETH {190.60 EUR} @ 190.60 EUR
               Expenses:Fees:Investments                                        0.00 EUR
               Assets:Investments                                               0.00 EUR
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )
 

--- a/tests/ledger_test.py
+++ b/tests/ledger_test.py
@@ -23,11 +23,14 @@ from beancount.parser import cmptest
 from beancount import loader
 
 import beancount2ledger
-from beancount2ledger.common import quote_currency, postings_by_type, split_currency_conversions
+from beancount2ledger.common import (
+    quote_currency,
+    postings_by_type,
+    split_currency_conversions,
+)
 
 
 class TestLedgerUtilityFunctions(cmptest.TestCase):
-
     def test_quote_currency(self):
         test = """
           2014-10-01 * "Buy some stock with local funds"
@@ -59,28 +62,27 @@ class TestLedgerUtilityFunctions(cmptest.TestCase):
 
 
 class TestLedgerUtilityFunctionsOnPostings(cmptest.TestCase):
-
     @loader.load_doc()
     def setUp(self, entries, _, __):
         """
-          2000-01-01 open Assets:CA:Investment:HOOL
-          2000-01-01 open Expenses:Commissions
-          2000-01-01 open Assets:CA:Investment:Cash
+        2000-01-01 open Assets:CA:Investment:HOOL
+        2000-01-01 open Expenses:Commissions
+        2000-01-01 open Assets:CA:Investment:Cash
 
-          2014-10-01 * "Buy some stock with local funds"
-            Assets:CA:Investment:HOOL          5 HOOL {500.00 USD}
-            Expenses:Commissions            9.95 USD
-            Assets:CA:Investment:Cash   -2509.95 USD
+        2014-10-01 * "Buy some stock with local funds"
+          Assets:CA:Investment:HOOL          5 HOOL {500.00 USD}
+          Expenses:Commissions            9.95 USD
+          Assets:CA:Investment:Cash   -2509.95 USD
 
-          2014-10-02 * "Regular price conversion with fee"
-            Assets:CA:Investment:Cash    2500.00 USD
-            Expenses:Commissions            9.95 USD
-            Assets:CA:Investment:Cash   -2826.84 CAD @ 0.8879 USD
+        2014-10-02 * "Regular price conversion with fee"
+          Assets:CA:Investment:Cash    2500.00 USD
+          Expenses:Commissions            9.95 USD
+          Assets:CA:Investment:Cash   -2826.84 CAD @ 0.8879 USD
 
-          2014-10-03 * "Buy some stock with foreign currency funds"
-            Assets:CA:Investment:HOOL          5 HOOL {520.0 USD}
-            Expenses:Commissions            9.95 USD
-            Assets:CA:Investment:Cash   -2939.46 CAD @ 0.8879 USD
+        2014-10-03 * "Buy some stock with foreign currency funds"
+          Assets:CA:Investment:HOOL          5 HOOL {520.0 USD}
+          Expenses:Commissions            9.95 USD
+          Assets:CA:Investment:Cash   -2939.46 CAD @ 0.8879 USD
         """
         self.txns = [entry for entry in entries if isinstance(entry, data.Transaction)]
 
@@ -103,7 +105,8 @@ class TestLedgerUtilityFunctionsOnPostings(cmptest.TestCase):
 
         converted, new_entries = split_currency_conversions(self.txns[2])
         self.assertTrue(converted)
-        self.assertEqualEntries("""
+        self.assertEqualEntries(
+            """
 
           2014-10-03 * "Buy some stock with foreign currency funds (Currency conversion)"
             Assets:CA:Investment:Cash       -2,939.46 CAD @ 0.8879 USD
@@ -114,7 +117,9 @@ class TestLedgerUtilityFunctionsOnPostings(cmptest.TestCase):
             Expenses:Commissions                 9.95 USD
             Assets:CA:Investment:Cash       -2,609.946534 USD
 
-        """, new_entries)
+        """,
+            new_entries,
+        )
 
 
 def get_ledger_version():
@@ -125,12 +130,14 @@ def get_ledger_version():
       if Ledger is not installed or could not be run.
     """
     try:
-        pipe = subprocess.Popen(['ledger', '--version'],
-                                shell=False,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        pipe = subprocess.Popen(
+            ["ledger", "--version"],
+            shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         stdout, stderr = pipe.communicate()
-        match = re.search(r'(\d+)\.(\d+)\.(\d+)', stdout.decode('utf-8'))
+        match = re.search(r"(\d+)\.(\d+)\.(\d+)", stdout.decode("utf-8"))
         if match:
             return tuple(map(int, match.group(1, 2, 3)))
     except OSError:
@@ -139,7 +146,6 @@ def get_ledger_version():
 
 
 class TestLedgerConversion(test_utils.TestCase):
-
     def check_parses_ledger(self, ledger_filename):
         """Assert that the filename parses through Ledger without errors.
 
@@ -148,34 +154,39 @@ class TestLedgerConversion(test_utils.TestCase):
         """
         version = get_ledger_version()
         if version is None or version < (3, 0, 0):
-            self.skipTest('Ledger is not installed or has insufficient version, '
-                          'cannot verify conversion; skipping test')
+            self.skipTest(
+                "Ledger is not installed or has insufficient version, "
+                "cannot verify conversion; skipping test"
+            )
 
-        pipe = subprocess.Popen(['ledger', '-f', ledger_filename, 'bal'],
-                                shell=False,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        pipe = subprocess.Popen(
+            ["ledger", "-f", ledger_filename, "bal"],
+            shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         stdout, stderr = pipe.communicate()
         self.assertEqual(0, pipe.returncode, stderr)
 
     @loader.load_doc()
     def test_simple(self, entries, _, __):
         """
-          ;; All supported features exhibited here.
+        ;; All supported features exhibited here.
 
-          2013-01-01 open Expenses:Restaurant
-          2013-01-01 open Assets:Cash         USD,CAD
+        2013-01-01 open Expenses:Restaurant
+        2013-01-01 open Assets:Cash         USD,CAD
 
-          2014-02-15 price HOOL 500.00 USD
+        2014-02-15 price HOOL 500.00 USD
 
-          2014-03-02 * "Something"
-            Expenses:Restaurant   50.02 USD
-            Assets:Cash
+        2014-03-02 * "Something"
+          Expenses:Restaurant   50.02 USD
+          Assets:Cash
 
-          2015-01-01 custom "budget" Expenses:Food  "yearly"  34.43 HRK
+        2015-01-01 custom "budget" Expenses:Food  "yearly"  34.43 HRK
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines("""
+        self.assertLines(
+            """
 
           account Expenses:Restaurant
 
@@ -188,24 +199,27 @@ class TestLedgerConversion(test_utils.TestCase):
             Expenses:Restaurant                                                     50.02 USD
             Assets:Cash
 
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_cost_and_foreign_currency(self, entries, _, __):
         """
-          plugin "beancount.plugins.implicit_prices"
+        plugin "beancount.plugins.implicit_prices"
 
-          2014-01-01 open Assets:CA:Investment:HOOL
-          2014-01-01 open Expenses:Commissions
-          2014-01-01 open Assets:CA:Investment:Cash
+        2014-01-01 open Assets:CA:Investment:HOOL
+        2014-01-01 open Expenses:Commissions
+        2014-01-01 open Assets:CA:Investment:Cash
 
-          2014-11-02 * "Buy some stock with foreign currency funds"
-            Assets:CA:Investment:HOOL          5 HOOL {520.0 USD}
-            Expenses:Commissions            9.95 USD
-            Assets:CA:Investment:Cash   -2939.46 CAD @ 0.8879 USD
+        2014-11-02 * "Buy some stock with foreign currency funds"
+          Assets:CA:Investment:HOOL          5 HOOL {520.0 USD}
+          Expenses:Commissions            9.95 USD
+          Assets:CA:Investment:Cash   -2939.46 CAD @ 0.8879 USD
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines("""
+        self.assertLines(
+            """
 
           account Assets:CA:Investment:HOOL
 
@@ -222,20 +236,23 @@ class TestLedgerConversion(test_utils.TestCase):
 
           P 2014-11-02 CAD    0.8879 USD
 
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_tags_links(self, entries, _, ___):
         """
-          2019-01-25 open Assets:A
-          2019-01-25 open Assets:B
+        2019-01-25 open Assets:A
+        2019-01-25 open Assets:B
 
-          2019-01-25 * "Test tags" #foo ^link2 #bar #baz ^link1
-            Assets:A                       10.00 EUR
-            Assets:B                      -10.00 EUR
+        2019-01-25 * "Test tags" #foo ^link2 #bar #baz ^link1
+          Assets:A                       10.00 EUR
+          Assets:B                      -10.00 EUR
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines("""
+        self.assertLines(
+            """
           account Assets:A
 
           account Assets:B
@@ -245,12 +262,14 @@ class TestLedgerConversion(test_utils.TestCase):
             ; Link: link1, link2
             Assets:A                       10.00 EUR
             Assets:B                      -10.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_account_open(self, entries, _, ___):
         """
-          2019-01-25 open Assets:A
+        2019-01-25 open Assets:A
         """
         result = beancount2ledger.convert(entries)
         self.assertEqual("account Assets:A\n", result)
@@ -258,20 +277,21 @@ class TestLedgerConversion(test_utils.TestCase):
     @loader.load_doc()
     def test_metadata_entry(self, entries, _, ___):
         """
-          2020-01-01 open Assets:Test
+        2020-01-01 open Assets:Test
 
-          2020-07-23 * "Test metadata"
-            string: "foo"
-            year: 2020
-            amount: 10.00 EUR
-            date: 2020-07-19
-            none:
-            bool: TRUE
-            Assets:Test     10.00 EUR
-            Assets:Test    -10.00 EUR
+        2020-07-23 * "Test metadata"
+          string: "foo"
+          year: 2020
+          amount: 10.00 EUR
+          date: 2020-07-19
+          none:
+          bool: TRUE
+          Assets:Test     10.00 EUR
+          Assets:Test    -10.00 EUR
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines("""
+        self.assertLines(
+            """
           account Assets:Test
 
           2020-07-23 * Test metadata
@@ -283,25 +303,28 @@ class TestLedgerConversion(test_utils.TestCase):
             ; bool:: true
             Assets:Test                                                      10.00 EUR
             Assets:Test                                                      -10.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_metadata_posting(self, entries, _, ___):
         """
-          2020-01-01 open Assets:Test
+        2020-01-01 open Assets:Test
 
-          2020-07-23 * "Test metadata"
-            Assets:Test     10.00 EUR
-            Assets:Test    -10.00 EUR
-            string: "foo"
-            year: 2020
-            amount: 10.00 EUR
-            date: 2020-07-19
-            none:
-            bool: FALSE
+        2020-07-23 * "Test metadata"
+          Assets:Test     10.00 EUR
+          Assets:Test    -10.00 EUR
+          string: "foo"
+          year: 2020
+          amount: 10.00 EUR
+          date: 2020-07-19
+          none:
+          bool: FALSE
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines("""
+        self.assertLines(
+            """
           account Assets:Test
 
           2020-07-23 * Test metadata
@@ -313,16 +336,18 @@ class TestLedgerConversion(test_utils.TestCase):
               ; date:: [2020-07-19]
               ; none:
               ; bool:: false
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_metadata_none(self, entries, _, ___):
         """
-          2000-01-01 open Assets:Test1
-          2000-01-01 open Assets:Test2
+        2000-01-01 open Assets:Test1
+        2000-01-01 open Assets:Test2
 
-          2019-01-21 pad Assets:Test1 Assets:Test2
-          2019-01-22 balance Assets:Test1   10.00 GBP
+        2019-01-21 pad Assets:Test1 Assets:Test2
+        2019-01-22 balance Assets:Test1   10.00 GBP
         """
         # padding (P) entries don't set entry.meta or posting.meta, so
         # convert to make sure we don't crash.
@@ -331,23 +356,24 @@ class TestLedgerConversion(test_utils.TestCase):
     @loader.load_doc()
     def test_cost_info(self, entries, _, ___):
         """
-          2020-01-01 open Expenses:Computers
-          2020-01-01 open Assets:Bank
+        2020-01-01 open Expenses:Computers
+        2020-01-01 open Assets:Bank
 
-          2020-02-01 * "Super Shop"  "New computer"
-            Expenses:Computers       1 COMPUTER {900.00 USD, 2019-12-25, "DiscountedComputer"} @ 1100.00 USD
-            Assets:Bank
+        2020-02-01 * "Super Shop"  "New computer"
+          Expenses:Computers       1 COMPUTER {900.00 USD, 2019-12-25, "DiscountedComputer"} @ 1100.00 USD
+          Assets:Bank
 
-          2020-02-02 * "Super Shop"  "New computer"
-            Expenses:Computers       1 COMPUTER {900.00 USD, "DiscountedComputer"} @ 1100.00 USD
-            Assets:Bank
+        2020-02-02 * "Super Shop"  "New computer"
+          Expenses:Computers       1 COMPUTER {900.00 USD, "DiscountedComputer"} @ 1100.00 USD
+          Assets:Bank
 
-          2020-02-03 * "Super Shop"  "New computer"
-            Expenses:Computers       1 COMPUTER {900.00 USD, 2019-12-25} @ 1100.00 USD
-            Assets:Bank
+        2020-02-03 * "Super Shop"  "New computer"
+          Expenses:Computers       1 COMPUTER {900.00 USD, 2019-12-25} @ 1100.00 USD
+          Assets:Bank
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines("""
+        self.assertLines(
+            """
           account Expenses:Computers
 
           account Assets:Bank
@@ -363,78 +389,84 @@ class TestLedgerConversion(test_utils.TestCase):
           2020-02-03 * Super Shop | New computer
             Expenses:Computers                      1 COMPUTER {900.00 USD} [2019-12-25] @ 1100.00 USD
             Assets:Bank
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_posting_alignment(self, entries, _, ___):
         """
-          2020-01-01 open Assets:Test
-          2020-01-01 open Assets:TestTestTestTestTestTestTestTestTestTestTestTest
-          2020-01-01 open Assets:TestTestTestTestTestTestTestTestTestTestTestTestTestTest
-          2010-01-01 open Assets:TestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTest
-          2020-07-17 * "Test alignment of postings"
-            * Assets:Test     1000000000.00 EUR
-            Assets:Test      -1000000000.00 EUR
-            * Assets:TestTestTestTestTestTestTestTestTestTestTestTest        1000.00 EUR
-            Assets:Test                                                     -1000.00 EUR
-            * Assets:TestTestTestTestTestTestTestTestTestTestTestTestTestTest     1000.00 EUR
-            Assets:Test                                                          -1000.00 EUR
-            Assets:TestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTest  1000.00 EUR
-            Assets:Test                                                                         -1000.00 EUR
-            * Assets:Test     100000.00 EUREUREUREUREUR
-            Assets:Test      -100000.00 EUREUREUREUREUR
+        2020-01-01 open Assets:Test
+        2020-01-01 open Assets:TestTestTestTestTestTestTestTestTestTestTestTest
+        2020-01-01 open Assets:TestTestTestTestTestTestTestTestTestTestTestTestTestTest
+        2010-01-01 open Assets:TestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTest
+        2020-07-17 * "Test alignment of postings"
+          * Assets:Test     1000000000.00 EUR
+          Assets:Test      -1000000000.00 EUR
+          * Assets:TestTestTestTestTestTestTestTestTestTestTestTest        1000.00 EUR
+          Assets:Test                                                     -1000.00 EUR
+          * Assets:TestTestTestTestTestTestTestTestTestTestTestTestTestTest     1000.00 EUR
+          Assets:Test                                                          -1000.00 EUR
+          Assets:TestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTest  1000.00 EUR
+          Assets:Test                                                                         -1000.00 EUR
+          * Assets:Test     100000.00 EUREUREUREUREUR
+          Assets:Test      -100000.00 EUREUREUREUREUR
         """
         result = beancount2ledger.convert(entries)
-        len_postings = [len(line) for line in result.rstrip().split('\n')]
+        len_postings = [len(line) for line in result.rstrip().split("\n")]
         self.assertEqual(len_postings[-10:-1:2], [75, 75, 80, 98, 75])
 
     @loader.load_doc()
     def test_posting_no_amount(self, entries, _, ___):
         """
-          2010-01-01 open Assets:Test
+        2010-01-01 open Assets:Test
 
-          2020-07-25 txn "No amount on second posting"
-            Assets:Test                        10.00 EUR
-            Assets:Test
+        2020-07-25 txn "No amount on second posting"
+          Assets:Test                        10.00 EUR
+          Assets:Test
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines("""
+        self.assertLines(
+            """
           account Assets:Test
 
           2020-07-25 * No amount on second posting
             Assets:Test                        10.00 EUR
             Assets:Test
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_price_alignment(self, entries, _, ___):
         """
-          2020-07-23 price EUR 1.16 USD
-          2020-07-24 price EUREUREUREUREUREUREUREUR 1.16 USD
-          2020-07-24 price EUREUREUREUREUREUREUREU1 1.16 USD
+        2020-07-23 price EUR 1.16 USD
+        2020-07-24 price EUREUREUREUREUREUREUREUR 1.16 USD
+        2020-07-24 price EUREUREUREUREUREUREUREU1 1.16 USD
         """
         result = beancount2ledger.convert(entries)
-        len_pricedb = [len(line) for line in result.rstrip().split('\n')]
+        len_pricedb = [len(line) for line in result.rstrip().split("\n")]
         self.assertEqual(len_pricedb[::2], [75, 75, 75])
 
     @loader.load_doc()
     def test_multiline_strings(self, entries, _, ___):
         """
-          2010-01-01 open Assets:Test
+        2010-01-01 open Assets:Test
 
-          2020-07-25 txn "Foo
-          bar" "Foo
-          bar
-          bar"
-            meta: "Foo
-          bar"
-            Assets:Test                        10.00 EUR
-            meta: "Foo
-          bar"
-            Assets:Test                       -10.00 EUR
+        2020-07-25 txn "Foo
+        bar" "Foo
+        bar
+        bar"
+          meta: "Foo
+        bar"
+          Assets:Test                        10.00 EUR
+          meta: "Foo
+        bar"
+          Assets:Test                       -10.00 EUR
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
           account Assets:Test
 
           2020-07-25 * Foo\nbar | Foo\nbar\nbar
@@ -442,23 +474,26 @@ class TestLedgerConversion(test_utils.TestCase):
             Assets:Test                                                     10.00 EUR
               ; meta: Foo\nbar
             Assets:Test                                                    -10.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_flags(self, entries, _, ___):
         """
-          2010-01-01 open Assets:Test
+        2010-01-01 open Assets:Test
 
-          2020-07-25 txn "Valid flags"
-            * Assets:Test                        10.00 EUR
-            ! Assets:Test
+        2020-07-25 txn "Valid flags"
+          * Assets:Test                        10.00 EUR
+          ! Assets:Test
 
-          2020-07-25 R "Invalid flags"
-            M Assets:Test                        10.00 EUR
-            S Assets:Test                       -10.00 EUR
+        2020-07-25 R "Invalid flags"
+          M Assets:Test                        10.00 EUR
+          S Assets:Test                       -10.00 EUR
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
           account Assets:Test
 
           2020-07-25 * Valid flags
@@ -468,43 +503,46 @@ class TestLedgerConversion(test_utils.TestCase):
           2020-07-25 Invalid flags
             Assets:Test                                                     10.00 EUR
             Assets:Test                                                    -10.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_auxdate(self, entries, _, ___):
         """
-            2020-01-01 open Assets:Test
-            2020-01-01 open Equity:Opening-Balance
+        2020-01-01 open Assets:Test
+        2020-01-01 open Equity:Opening-Balance
 
-            2020-11-12 * "Test with aux date"
-              aux-date: 2020-11-03
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Test with aux date"
+          aux-date: 2020-11-03
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Test with transaction and posting aux date"
-              aux-date: 2020-11-03
-              Assets:Test                        10.00 EUR
-                aux-date: 2020-11-04
-              Equity:Opening-Balance
+        2020-11-12 * "Test with transaction and posting aux date"
+          aux-date: 2020-11-03
+          Assets:Test                        10.00 EUR
+            aux-date: 2020-11-04
+          Equity:Opening-Balance
 
-            2020-11-12 * "Test with posting date"
-              Assets:Test                        10.00 EUR
-                date: 2020-11-03
-              Equity:Opening-Balance            -10.00 EUR
-                date: 2020-11-04
-                test: "foo"
+        2020-11-12 * "Test with posting date"
+          Assets:Test                        10.00 EUR
+            date: 2020-11-03
+          Equity:Opening-Balance            -10.00 EUR
+            date: 2020-11-04
+            test: "foo"
 
-            2020-11-12 * "Testing with posting date and posting aux date"
-              Assets:Test                        10.00 EUR
-                aux-date: 2020-11-04
-                date: 2020-11-03
-              Equity:Opening-Balance            -10.00 EUR
-                date: 2020-11-03
-                aux-date: 2020-11-04
-                test: "foo"
+        2020-11-12 * "Testing with posting date and posting aux date"
+          Assets:Test                        10.00 EUR
+            aux-date: 2020-11-04
+            date: 2020-11-03
+          Equity:Opening-Balance            -10.00 EUR
+            date: 2020-11-03
+            aux-date: 2020-11-04
+            test: "foo"
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             account Equity:Opening-Balance
@@ -535,11 +573,14 @@ class TestLedgerConversion(test_utils.TestCase):
                 ; date:: [2020-11-03]
                 ; aux-date:: [2020-11-04]
                 ; test: foo
-        """, result)
+        """,
+            result,
+        )
 
         config = {"auxdate": "aux-date", "postdate": "date"}
         result = beancount2ledger.convert(entries, config=config)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             account Equity:Opening-Balance
@@ -562,11 +603,14 @@ class TestLedgerConversion(test_utils.TestCase):
               Equity:Opening-Balance                                         -10.00 EUR  ; [2020-11-03=2020-11-04]
                 ; test: foo
 
-        """, result)
+        """,
+            result,
+        )
 
         config = {"auxdate": "aux-date"}
         result = beancount2ledger.convert(entries, config=config)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             account Equity:Opening-Balance
@@ -592,47 +636,50 @@ class TestLedgerConversion(test_utils.TestCase):
               Equity:Opening-Balance                                         -10.00 EUR  ; [=2020-11-04]
                 ; date:: [2020-11-03]
                 ; test: foo
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_code(self, entries, _, ___):
         """
-            2020-01-01 open Assets:Test
+        2020-01-01 open Assets:Test
 
-            2020-01-01 open Equity:Opening-Balance
+        2020-01-01 open Equity:Opening-Balance
 
-            2020-11-12 * "No code"
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "No code"
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Code is integer"
-              code: 1234
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Code is integer"
+          code: 1234
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Code is string"
-              code: "string"
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Code is string"
+          code: "string"
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Code is date"
-              code: 2020-11-12
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Code is date"
+          code: 2020-11-12
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Code is empty"
-              code:
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Code is empty"
+          code:
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
 
-            2020-11-12 * "Code and aux-date"
-              aux-date: 2020-11-03
-              code: 1234
-              Assets:Test                        10.00 EUR
-              Equity:Opening-Balance
+        2020-11-12 * "Code and aux-date"
+          aux-date: 2020-11-03
+          code: 1234
+          Assets:Test                        10.00 EUR
+          Equity:Opening-Balance
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             account Equity:Opening-Balance
@@ -666,11 +713,14 @@ class TestLedgerConversion(test_utils.TestCase):
               ; code:: 1234
               Assets:Test                                                     10.00 EUR
               Equity:Opening-Balance
-        """, result)
+        """,
+            result,
+        )
 
         config = {"code": "code", "auxdate": "aux-date"}
         result = beancount2ledger.convert(entries, config=config)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             account Equity:Opening-Balance
@@ -699,29 +749,32 @@ class TestLedgerConversion(test_utils.TestCase):
             2020-11-12=2020-11-03 * (1234) Code and aux-date
                 Assets:Test                                                   10.00 EUR
                 Equity:Opening-Balance
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_retain_precision(self, entries, _, ___):
         """
-            2010-01-01 open Expenses:Nutrition:Food
-            2010-01-01 open Assets:Bank
-            2010-01-01 open Assets:Investments
+        2010-01-01 open Expenses:Nutrition:Food
+        2010-01-01 open Assets:Bank
+        2010-01-01 open Assets:Investments
 
-            2020-01-10 * "Supermarket"
-              Expenses:Nutrition:Food  150.75 THB @ 0.03310116086236 USD
-              Assets:Bank                                      -4.99 USD
+        2020-01-10 * "Supermarket"
+          Expenses:Nutrition:Food  150.75 THB @ 0.03310116086236 USD
+          Assets:Bank                                      -4.99 USD
 
-            2020-01-10 * "Supermarket"
-              Expenses:Nutrition:Food  150.75 THB @ 0.025207296849 GBP
-              Assets:Bank                                    -3.80 GBP
+        2020-01-10 * "Supermarket"
+          Expenses:Nutrition:Food  150.75 THB @ 0.025207296849 GBP
+          Assets:Bank                                    -3.80 GBP
 
-            2020-02-28 * "Bought GB00BPN5P782"
-              Assets:Investments           1 GB00BPN5P782 {101.689996215 GBP}
-              Assets:Investments                                 -101.69 GBP
+        2020-02-28 * "Bought GB00BPN5P782"
+          Assets:Investments           1 GB00BPN5P782 {101.689996215 GBP}
+          Assets:Investments                                 -101.69 GBP
         """
         result = beancount2ledger.convert(entries, "ledger")
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Expenses:Nutrition:Food
 
             account Assets:Bank
@@ -739,28 +792,31 @@ class TestLedgerConversion(test_utils.TestCase):
             2020-02-28 * Bought GB00BPN5P782
               Assets:Investments                   1 "GB00BPN5P782" {101.689996215 GBP}
               Assets:Investments                                            -101.69 GBP
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_rounding(self, entries, _, ___):
         """
-            2010-01-01 open Expenses:Test
-            2010-01-01 open Assets:Bank
+        2010-01-01 open Expenses:Test
+        2010-01-01 open Assets:Bank
 
-            2020-01-10 * "Test"
-              Expenses:Test                           4.990 USD
-              Assets:Bank                            -4.990 USD
+        2020-01-10 * "Test"
+          Expenses:Test                           4.990 USD
+          Assets:Bank                            -4.990 USD
 
-            2020-01-10 * "Test: will fail in ledger due to precision of USD"
-              Expenses:Test            150.75 THB @ 0.03344 USD
-              Assets:Bank                             -5.04 USD
+        2020-01-10 * "Test: will fail in ledger due to precision of USD"
+          Expenses:Test            150.75 THB @ 0.03344 USD
+          Assets:Bank                             -5.04 USD
 
-            2020-01-10 * "Test: will fail in ledger due to precision of USD"
-              Expenses:Test               140.1 THB @ 0.021 USD
-              Assets:Bank                             -2.94 USD
+        2020-01-10 * "Test: will fail in ledger due to precision of USD"
+          Expenses:Test               140.1 THB @ 0.021 USD
+          Assets:Bank                             -2.94 USD
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Expenses:Test
 
             account Assets:Bank
@@ -778,28 +834,31 @@ class TestLedgerConversion(test_utils.TestCase):
               Expenses:Test                                                   140.10 THB @ 0.021 USD
               Assets:Bank                                                     -2.940 USD
               Equity:Rounding                                                 -0.002 USD
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_avoid_too_much_precision(self, entries, _, ___):
         """
-            2020-01-01 open Assets:Property
-            2020-01-01 open Equity:Opening-Balance
+        2020-01-01 open Assets:Property
+        2020-01-01 open Equity:Opening-Balance
 
-            2020-10-23 * "Test of precision for EUR"
-                Assets:Property               0.11110000 FOO {300.00 EUR}
-                Equity:Opening-Balance                        -33.33 EUR
+        2020-10-23 * "Test of precision for EUR"
+            Assets:Property               0.11110000 FOO {300.00 EUR}
+            Equity:Opening-Balance                        -33.33 EUR
 
-            2020-10-23 * "Test of precision for EUR"
-                Assets:Property               0.11110000 FOO {300.00 EUR}
-                Equity:Opening-Balance
+        2020-10-23 * "Test of precision for EUR"
+            Assets:Property               0.11110000 FOO {300.00 EUR}
+            Equity:Opening-Balance
 
-            2020-10-23 * "Test of precision for EUR"
-                Assets:Property                   0.1111 FOO {300.00 EUR}
-                Equity:Opening-Balance
+        2020-10-23 * "Test of precision for EUR"
+            Assets:Property                   0.1111 FOO {300.00 EUR}
+            Equity:Opening-Balance
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Property
 
             account Equity:Opening-Balance
@@ -815,21 +874,24 @@ class TestLedgerConversion(test_utils.TestCase):
             2020-10-23 * Test of precision for EUR
               Assets:Property                               0.11110000 FOO {300.00 EUR}
               Equity:Opening-Balance
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_avoid_multiple_null_postings(self, entries, _, ___):
         """
-            2010-01-01 open Assets:Cash
-            2010-01-01 open Equity:Opening-balance
+        2010-01-01 open Assets:Cash
+        2010-01-01 open Equity:Opening-balance
 
-            2020-01-01 * "Opening balance: cash"
-              Assets:Cash                                               0.10 EUR
-              Assets:Cash                                               1.00 GBP
-              Equity:Opening-balance
+        2020-01-01 * "Opening balance: cash"
+          Assets:Cash                                               0.10 EUR
+          Assets:Cash                                               1.00 GBP
+          Equity:Opening-balance
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Cash
 
             account Equity:Opening-balance
@@ -838,21 +900,24 @@ class TestLedgerConversion(test_utils.TestCase):
               Assets:Cash                                                       0.10 EUR
               Assets:Cash                                                       1.00 GBP
               Equity:Opening-balance
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_add_price_when_needed(self, entries, _, ___):
         """
-            2020-01-01 open Assets:Property
-            2020-01-01 open Equity:Opening-Balance
+        2020-01-01 open Assets:Property
+        2020-01-01 open Equity:Opening-Balance
 
-            2020-11-13 * "We need to add @ price due to ledger bug #630"
-                Assets:Property                   0.1 FOO {300.00 EUR}
-                Assets:Property                   0.2 BAR {200.00 EUR}
-                Equity:Opening-Balance         -70.00 EUR
+        2020-11-13 * "We need to add @ price due to ledger bug #630"
+            Assets:Property                   0.1 FOO {300.00 EUR}
+            Assets:Property                   0.2 BAR {200.00 EUR}
+            Equity:Opening-Balance         -70.00 EUR
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Property
 
             account Equity:Opening-Balance
@@ -861,21 +926,24 @@ class TestLedgerConversion(test_utils.TestCase):
               Assets:Property                                      0.1 FOO {300.00 EUR} @ 300.00 EUR
               Assets:Property                                      0.2 BAR {200.00 EUR} @ 200.00 EUR
               Equity:Opening-Balance                                         -70.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_keep_zero_amounts(self, entries, _, ___):
         """
-            2010-01-01 open Assets:Investments
-            2010-01-01 open Expenses:Fees:Investments
+        2010-01-01 open Assets:Investments
+        2010-01-01 open Expenses:Fees:Investments
 
-            2020-05-24 * "Bought ETH"
-              Assets:Investments                     0.00000221 ETH {190.60 EUR}
-              Expenses:Fees:Investments                                 0.00 EUR
-              Assets:Investments                                       -0.00 EUR
+        2020-05-24 * "Bought ETH"
+          Assets:Investments                     0.00000221 ETH {190.60 EUR}
+          Expenses:Fees:Investments                                 0.00 EUR
+          Assets:Investments                                       -0.00 EUR
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Investments
 
             account Expenses:Fees:Investments
@@ -884,23 +952,26 @@ class TestLedgerConversion(test_utils.TestCase):
               Assets:Investments                            0.00000221 ETH {190.60 EUR} @ 190.60 EUR
               Expenses:Fees:Investments                                        0.00 EUR
               Assets:Investments                                               0.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     @loader.load_doc()
     def test_preserve_posting_order(self, entries, _, ___):
         """
-            2010-01-01 open Assets:Test
+        2010-01-01 open Assets:Test
 
-            2020-07-24 * "Posting order"
-              Assets:Test        1000.00 EUR
-              Assets:Test       -1000.00 EUR
-              Assets:Test        1000.00 EUREUREUREUREUR
-              Assets:Test       -1000.00 EUREUREUREUREUR
-              Assets:Test        1000.00 EUR
-              Assets:Test       -1000.00 EUR
+        2020-07-24 * "Posting order"
+          Assets:Test        1000.00 EUR
+          Assets:Test       -1000.00 EUR
+          Assets:Test        1000.00 EUREUREUREUREUR
+          Assets:Test       -1000.00 EUREUREUREUREUR
+          Assets:Test        1000.00 EUR
+          Assets:Test       -1000.00 EUR
         """
         result = beancount2ledger.convert(entries)
-        self.assertLines(r"""
+        self.assertLines(
+            r"""
             account Assets:Test
 
             2020-07-24 * Posting order
@@ -910,30 +981,34 @@ class TestLedgerConversion(test_utils.TestCase):
               Assets:Test                                       -1000.00 EUREUREUREUREUR
               Assets:Test                                                    1000.00 EUR
               Assets:Test                                                   -1000.00 EUR
-        """, result)
+        """,
+            result,
+        )
 
     def test_example(self):
-        with tempfile.NamedTemporaryFile('w',
-                                         suffix='.beancount',
-                                         encoding='utf-8') as beanfile:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".beancount", encoding="utf-8"
+        ) as beanfile:
             # Generate an example Beancount file.
-            example.write_example_file(datetime.date(1980, 1, 1),
-                                       datetime.date(2010, 1, 1),
-                                       datetime.date(2014, 1, 1),
-                                       reformat=True,
-                                       file=beanfile)
+            example.write_example_file(
+                datetime.date(1980, 1, 1),
+                datetime.date(2010, 1, 1),
+                datetime.date(2014, 1, 1),
+                reformat=True,
+                file=beanfile,
+            )
             beanfile.flush()
 
             # Convert the file to Ledger format.
-            with tempfile.NamedTemporaryFile('w', suffix='.ledger') as lgrfile:
+            with tempfile.NamedTemporaryFile("w", suffix=".ledger") as lgrfile:
                 result = beancount2ledger.convert_file(beanfile.name)
                 lgrfile.write(result)
                 lgrfile.flush()
 
                 # FIXME: Use a proper temp dir.
-                shutil.copyfile(lgrfile.name, '/tmp/test.ledger')
+                shutil.copyfile(lgrfile.name, "/tmp/test.ledger")
                 self.check_parses_ledger(lgrfile.name)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/mapping_test.py
+++ b/tests/mapping_test.py
@@ -105,6 +105,6 @@ class TestMappingConversion(test_utils.TestCase):
             2020-11-13 * Test
                 Assets:My Test                                                 1000.00 "TEST1"
                 Assets:My Test
-        """,
+        """,  # NoQA: E501 line too long
             result,
         )

--- a/tests/mapping_test.py
+++ b/tests/mapping_test.py
@@ -83,15 +83,15 @@ class TestMappingConversion(test_utils.TestCase):
     @loader.load_doc()
     def test_posting(self, entries, _, __):
         """
-          2020-01-01 open Assets:Test
+        2020-01-01 open Assets:Test
 
-          2020-11-13 * "Test"
-            Assets:Test        1000.00 EUR
-            Assets:Test
+        2020-11-13 * "Test"
+          Assets:Test        1000.00 EUR
+          Assets:Test
 
-          2020-11-13 * "Test"
-            Assets:Test        1000.00 TEST
-            Assets:Test
+        2020-11-13 * "Test"
+          Assets:Test        1000.00 TEST
+          Assets:Test
         """
         result = beancount2ledger.convert(entries, config=self.config)
         self.assertLines(
@@ -105,4 +105,6 @@ class TestMappingConversion(test_utils.TestCase):
             2020-11-13 * Test
                 Assets:My Test                                                 1000.00 "TEST1"
                 Assets:My Test
-        """, result)
+        """,
+            result,
+        )


### PR DESCRIPTION
I'm proposing this separating things in commits, so that automated formatting
is in a single commit that does nothing else than code reformatting. Other
commits first setup the configuration and then enables black checking in the
CI, so that (hopefully...) no commit in the series fail the CI.