### PR TITLE
Add PyYAML to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 beancount>=2.0
+PyYAML>=6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     beancount>=2.0.0
+    PyYAML>=6.0
 python_requires = >=3.6
 
 [options.entry_points]


### PR DESCRIPTION
Adds missing dependencies for PyYAML. I opted for the most recent major release 6.

Fixes #31 