### PR TITLE
add "payee-meta" configuration option to store payee as metadata

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 25 utf-8
+personal_ws-1.1 en 27 utf-8
 Alen
 Blais
 FileCopyrightText
@@ -9,11 +9,13 @@ Rawal
 Relicense
 SPDX
 Siljak
+Stefano
 THB
 USD
 Vikas
 Wiegley
 XDG
+Zacchiroli
 auxdate
 beancount
 beancount's

--- a/beancount2ledger/ledger.py
+++ b/beancount2ledger/ledger.py
@@ -104,14 +104,19 @@ class LedgerPrinter:
         # rounding amounts to 0.00)
         entry = filter_rounding_postings(entry, self.dformat)
 
+        meta = user_meta(entry.meta or {})
+
         # Compute the string for the payee and narration line.
         strings = []
         if entry.payee:
-            strings.append(f"{ledger_str(entry.payee)} |")
+            payee_meta = self.config.get("payee-meta")
+            if payee_meta:
+                meta[payee_meta] = entry.payee
+            else:
+                strings.append(f"{ledger_str(entry.payee)} |")
         if entry.narration:
             strings.append(ledger_str(entry.narration))
 
-        meta = user_meta(entry.meta or {})
         self.io.write(f"{entry.date:%Y-%m-%d}")
         auxdate_key = self.config.get("auxdate")
         if auxdate_key and isinstance(meta.get(auxdate_key), datetime.date):

--- a/docs/authors.md
+++ b/docs/authors.md
@@ -14,6 +14,7 @@ We have also had contributions and input from:
 * Marin Bernard (bug reports)
 * Simon Michael (help with compatibility with hledger)
 * Software in the Public Interest, Inc. (fixes)
+* Stefano Zacchiroli (fixes)
 * Vikas Rawal (bug reports)
 
 Thank you to all contributors and users!

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,12 @@ postdate
 code
 :   A metadata key that specifies metadata that should become the code of a transaction.
 
+### Information to metadata
+
+payee-meta
+
+:   A metadata key that specifies where to store the payee of a transaction, instead of using the `payee | narration` syntax (which is the default).
+
 ### Mappings
 
 account_map

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -109,11 +109,13 @@ For ledger output, metadata types other than strings will be converted to [typed
 
 ## Payee and narration
 
-Unlike beancount, ledger does not differentiate between payee and narration.  Therefore, the following syntax is used for ledger's payee field:
+Unlike beancount, ledger does not differentiate between payee and narration.  Therefore, the following syntax is used for ledger's payee field by default:
 
 ```
 payee | narration
 ```
+
+Alternatively, you can use the `payee-meta` config variable to store the payee in a custom metadata key.
 
 This is also the syntax used by hledger (where narration is called a [note](https://hledger.org/journal.html#payee-and-note)).
 


### PR DESCRIPTION
When set, this overrides the default behaviour of using the "payee | narration"
hledger syntax.
