### PR TITLE
Fix build failure due to missing man pages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,12 +45,6 @@ console_scripts =
 [options.packages.find]
 exclude = tests
 
-[options.data_files]
-share/man/man1 =
-    docs/beancount2ledger.1
-share/man/man5 =
-    docs/beancount2ledger.5
-
 [flake8]
 # E203: whitespaces before ':' <https://github.com/psf/black/issues/315>
 # E231: missing whitespace after ','

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,38 @@
 Setup script
 """
 
+import os
+import subprocess
 import setuptools
 
+def generate_man_pages():
+    """Generate man pages from scdoc sources if scdoc is available."""
+    man_pages = {
+        "docs/beancount2ledger.1": "docs/beancount2ledger.1.scd",
+        "docs/beancount2ledger.5": "docs/beancount2ledger.5.scd",
+    }
+    for output, source in man_pages.items():
+        if os.path.exists(output):
+            continue
+        if not os.path.exists(source):
+            continue
+        try:
+            with open(source, "r") as src, open(output, "w") as dst:
+                subprocess.run(["scdoc"], stdin=src, stdout=dst, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            # scdoc not available or failed; skip man page generation
+            if os.path.exists(output):
+                os.remove(output)
+
+def get_data_files():
+    """Return data_files list with only man pages that exist."""
+    generate_man_pages()
+    data_files = []
+    if os.path.exists("docs/beancount2ledger.1"):
+        data_files.append(("share/man/man1", ["docs/beancount2ledger.1"]))
+    if os.path.exists("docs/beancount2ledger.5"):
+        data_files.append(("share/man/man5", ["docs/beancount2ledger.5"]))
+    return data_files
+
 if __name__ == "__main__":
-    setuptools.setup()
+    setuptools.setup(data_files=get_data_files())


### PR DESCRIPTION
Generate man pages from scdoc sources during setup.py execution instead of requiring them to be pre-built. The data_files entry is moved from setup.cfg to setup.py where it's computed dynamically:

- If scdoc is available, man pages are generated from .scd sources
- If scdoc is unavailable, man pages are simply omitted
- If man pages already exist (pre-built), they are used as-is

This fixes the 'can't copy docs/beancount2ledger.1: doesn't exist' error when installing from git.

Fixes: #42